### PR TITLE
feat: add configurable cycle limits for pomodoro modes (Vibe Kanban)

### DIFF
--- a/src/components/ScheduleSelector.vue
+++ b/src/components/ScheduleSelector.vue
@@ -38,7 +38,11 @@ export default {
 			return Object.values(SCHEDULE_PRESETS);
 		},
 		activeSchedule() {
-			return getActiveSchedule();
+			// acceder directamente al store para mantener reactividad
+			if (this.currentId === 'custom' && scheduleStore.customConfig) {
+				return scheduleStore.customConfig;
+			}
+			return SCHEDULE_PRESETS[this.currentId] ?? SCHEDULE_PRESETS['okticket'];
 		},
 		isManualMode() {
 			return !this.activeSchedule.useWorkHours;

--- a/src/components/ScheduleSelector.vue
+++ b/src/components/ScheduleSelector.vue
@@ -146,6 +146,7 @@ export default {
 				<div class="help-tooltip">
 					<code>workMinutes</code> work duration (1-120)<br>
 					<code>breakMinutes</code> break duration (1-60)<br>
+					<code>cycles</code> (optional) number of cycles, null=infinite<br>
 					<code>workHours</code> (optional) restricts to hours:<br>
 					<span class="help-indent">simple: <code>[[9,14],[16,18]]</code></span><br>
 					<span class="help-indent">by day: <code>{"default":[...],"friday":[...]}</code></span><br>

--- a/src/components/ScheduleSelector.vue
+++ b/src/components/ScheduleSelector.vue
@@ -10,7 +10,8 @@ import {
 	resumeTimer,
 	stopTimer,
 	enableNotifications,
-	disableNotifications
+	disableNotifications,
+	setCycles
 } from '../stores/schedule.js';
 
 export default {
@@ -20,6 +21,7 @@ export default {
 			showCustomInput: false,
 			customJson: scheduleStore.customJson || this.getDefaultCustomJson(),
 			customError: '',
+			cyclesInput: '',
 		};
 	},
 	computed: {
@@ -40,6 +42,10 @@ export default {
 		},
 		isManualMode() {
 			return !this.activeSchedule.useWorkHours;
+		},
+		showCyclesInput() {
+			// mostrar input de ciclos para modos manuales (no okticket) cuando el timer está detenido
+			return this.isManualMode && this.timerState === 'stopped';
 		},
 	},
 	methods: {
@@ -71,6 +77,11 @@ export default {
 		},
 		onStart() {
 			startTimer();
+			// aplicar ciclos del input si se especificó un número válido
+			const cycles = parseInt(this.cyclesInput, 10);
+			if (!isNaN(cycles) && cycles >= 1) {
+				setCycles(cycles);
+			}
 		},
 		onPause() {
 			pauseTimer();
@@ -110,6 +121,14 @@ export default {
 			</select>
 
 			<template v-if="isManualMode">
+				<input
+					v-if="showCyclesInput"
+					v-model="cyclesInput"
+					type="text"
+					class="cycles-input"
+					placeholder="∞"
+					title="Number of cycles (empty = infinite)"
+				>
 				<button
 					v-if="timerState === 'stopped'"
 					class="btn control-btn"
@@ -199,6 +218,26 @@ export default {
 .control-btn {
 	font-size: 0.6em;
 	padding: 0.25em 0.75em;
+}
+
+.cycles-input {
+	width: 2.5em;
+	background: black;
+	color: white;
+	border: 1px solid #333;
+	padding: 0.25em 0.4em;
+	font-family: inherit;
+	font-size: 0.6em;
+	text-align: center;
+
+	&:hover, &:focus {
+		border-color: white;
+		outline: none;
+	}
+
+	&::placeholder {
+		color: #666;
+	}
 }
 
 .btn-stop {

--- a/src/components/timer/Timer.scss
+++ b/src/components/timer/Timer.scss
@@ -21,6 +21,13 @@
 	#countdown {
 		align-self: center;
 	}
+
+	#cycles {
+		font-size: min(6vw, 2em);
+		color: $alt-color;
+		margin-left: 0.5em;
+		align-self: center;
+	}
 }
 
 div {

--- a/src/components/timer/Timer.vue
+++ b/src/components/timer/Timer.vue
@@ -471,17 +471,24 @@ export default {
 		};
 	},
 	computed: {
+		cyclesLeft() {
+			return scheduleStore.cyclesLeft;
+		},
+		timerState() {
+			return scheduleStore.timerState;
+		},
+		activeScheduleId() {
+			return scheduleStore.currentId;
+		},
 		showCycles() {
-			const schedule = getActiveSchedule();
 			// no mostrar para okticket
-			if (schedule.id === 'okticket') return false;
-			// mostrar solo si hay ciclos finitos configurados
-			return scheduleStore.cyclesLeft !== Infinity && scheduleStore.timerState !== 'stopped';
+			if (this.activeScheduleId === 'okticket') return false;
+			// mostrar solo si hay ciclos finitos configurados y timer activo
+			return this.cyclesLeft !== Infinity && this.timerState !== 'stopped';
 		},
 		cyclesDisplay() {
-			const left = scheduleStore.cyclesLeft;
-			if (left === Infinity) return '';
-			return `×${left}`;
+			if (this.cyclesLeft === Infinity) return '';
+			return `×${this.cyclesLeft}`;
 		},
 	},
 	methods: {

--- a/src/config/schedules.js
+++ b/src/config/schedules.js
@@ -225,7 +225,7 @@ export const validateCustomSchedule = (config) => {
 		return { valid: false, error: 'debe ser un objeto JSON válido' };
 	}
 
-	const { workMinutes, breakMinutes, workHours } = config;
+	const { workMinutes, breakMinutes, workHours, cycles } = config;
 
 	if (typeof workMinutes !== 'number' || workMinutes < 1 || workMinutes > 120) {
 		return { valid: false, error: 'workMinutes debe ser un número entre 1 y 120' };
@@ -233,6 +233,13 @@ export const validateCustomSchedule = (config) => {
 
 	if (typeof breakMinutes !== 'number' || breakMinutes < 1 || breakMinutes > 60) {
 		return { valid: false, error: 'breakMinutes debe ser un número entre 1 y 60' };
+	}
+
+	// validar cycles si está presente (null o undefined = infinito)
+	if (cycles !== undefined && cycles !== null) {
+		if (typeof cycles !== 'number' || !Number.isInteger(cycles) || cycles < 1) {
+			return { valid: false, error: 'cycles debe ser un entero >= 1 (o null para infinito)' };
+		}
 	}
 
 	// validar workHours si está presente
@@ -268,6 +275,8 @@ export const parseCustomSchedule = (jsonString) => {
 				breakMinutes: config.breakMinutes,
 				useWorkHours: hasWorkHours,
 				workHours: config.workHours ?? null,
+				// cycles: undefined/null = infinito, número = límite
+				cycles: config.cycles ?? null,
 			}
 		};
 	} catch (e) {

--- a/src/stores/schedule.js
+++ b/src/stores/schedule.js
@@ -82,6 +82,15 @@ export const initializeCycles = () => {
 };
 
 /**
+ * Establece el número de ciclos manualmente.
+ * @param {number|null} cycles - número de ciclos o null para infinito
+ */
+export const setCycles = (cycles) => {
+	scheduleStore.cyclesLeft = cycles ?? INFINITE_CYCLES;
+	scheduleStore.currentCycleIndex = 0;
+};
+
+/**
  * Decrementa el contador de ciclos.
  * @returns {boolean} true si se agotaron los ciclos
  */


### PR DESCRIPTION
## Summary

This PR introduces a "cycles left" feature that allows users to define how many work/break loops the timer will complete before automatically stopping.

## Changes Made

### Core Features
- **Cycle tracking in store** (`src/stores/schedule.js`):
  - Added `cyclesLeft` and `currentCycleIndex` to reactive state
  - Added `setCycles()`, `initializeCycles()`, `decrementCycle()`, and `getConfiguredCycles()` functions
  - Cycles are initialized on timer start and reset on timer stop

- **Cycle configuration for custom mode** (`src/config/schedules.js`):
  - Added `cycles` field validation (integer >= 1, or null for infinite)
  - Custom mode JSON now supports `"cycles": N` property

- **Cycle display in timer** (`src/components/timer/Timer.vue`):
  - Shows `×N` indicator next to countdown when cycles are finite
  - Auto-decrements when transitioning from work → pause
  - Auto-stops timer when cycles are exhausted

- **Cycle input for standard modes** (`src/components/ScheduleSelector.vue`):
  - Added input field (placeholder `∞`) to set cycles before starting
  - Visible only for manual modes (standard-25, standard-50, custom without workHours)
  - Empty input = infinite cycles (default behavior)

### Behavior
- **All preset modes**: Infinite cycles by default
- **Custom mode**: Can define `cycles` in JSON config (e.g., `{"workMinutes": 25, "breakMinutes": 5, "cycles": 4}`)
- **okticket mode**: Excluded from cycle counting (uses hardcoded schedule)

## Implementation Details
- Used `Infinity` constant to represent unlimited cycles
- Fixed Vue reactivity issues by ensuring computed properties properly track store dependencies
- Cycle count decrements only on natural work→pause transitions (not user-triggered changes)

---

This PR was written using [Vibe Kanban](https://vibekanban.com)